### PR TITLE
Small Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(uav_ros)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -10,6 +10,11 @@ find_package(catkin REQUIRED COMPONENTS
 
 include_directories(include include/Preflight ${catkin_INCLUDE_DIRS})
 
+target_precopiled_headers(pch PUBLIC include/pch.hpp)
+
+add_library(core src/core/Application.cpp src/core/PX4.cpp)
+target_precompile_headers(core include/pch.hpp)
+
 add_executable(safety_test src/Preflight/safety_test.cpp src/Preflight/safety_check.cpp)
-target_link_libraries(safety_test ${catkin_LIBRARIES})
-add_dependencies(safety_test ${catkin_EXPORTED_TARGETS})
+target_link_libraries(safety_test core ${catkin_LIBRARIES})
+add_dependencies(safety_test core ${catkin_EXPORTED_TARGETS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
 
 include_directories(include include/Preflight ${catkin_INCLUDE_DIRS})
 
-target_precopiled_headers(pch PUBLIC include/pch.hpp)
-
 add_library(core src/core/Application.cpp src/core/PX4.cpp)
-target_precompile_headers(core include/pch.hpp)
+target_precompile_headers(core PUBLIC include/pch.hpp)
 
 add_executable(safety_test src/Preflight/safety_test.cpp src/Preflight/safety_check.cpp)
 target_link_libraries(safety_test core ${catkin_LIBRARIES})

--- a/include/Preflight/safety_check.hpp
+++ b/include/Preflight/safety_check.hpp
@@ -1,6 +1,4 @@
-#ifndef SAFETY_CHECK_H
-#define SAFETY_CHECK_H
-
+#pragma once
 #include <ros/ros.h>
 #include <mavros_msgs/CommandBool.h>
 #include <mavros_msgs/SetMode.h>
@@ -28,5 +26,3 @@ class safety_check{
 
     bool connected();
 };
-
-#endif SAFETY_CHECK_H


### PR DESCRIPTION
Some small fixes that will make this project compile.

- Forcing the use of CMake 3.16 as that's the version pre-compiled headers are supported.
- Replaced old header guard with `#pragma once`